### PR TITLE
Fix DNS naming | 'tox#' → 'toxdns#'

### DIFF
--- a/src/toxdns.h
+++ b/src/toxdns.h
@@ -22,11 +22,11 @@
 #include <QDnsLookup>
 #include <QObject>
 
-/// Tox1 is not encrypted, it's unsafe
-#define TOX1_SILENT_FALLBACK 0
+/// ToxDNS1 is not encrypted, it's unsafe
+#define TOXDNS1_SILENT_FALLBACK 0
 
 /// That said if the user insists ...
-#define TOX1_ASK_FALLBACK 1
+#define TOXDNS1_ASK_FALLBACK 1
 
 /// Handles tox1 and tox3 DNS queries
 class ToxDNS : public QObject
@@ -34,21 +34,21 @@ class ToxDNS : public QObject
     Q_OBJECT
 
 public:
-    struct tox3_server ///< Represents a tox3 server
+    struct toxdns3_server ///< Represents a toxdns3 server
     {
-        tox3_server()=default;
-        tox3_server(const char* _name, uint8_t _pk[32]):name{_name},pubkey{_pk}{}
+        toxdns3_server()=default;
+        toxdns3_server(const char* _name, uint8_t _pk[32]):name{_name},pubkey{_pk}{}
 
         const char* name; ///< Hostname of the server, e.g. toxme.se
-        uint8_t* pubkey; ///< Public key of the tox3 server, usually 256bit long
+        uint8_t* pubkey; ///< Public key of the toxdns3 server, usually 256bit long
     };
 
 public:
     /// Tries to map a text string to a ToxID struct, will query Tox DNS records if necessary
     static ToxID resolveToxAddress(const QString& address, bool silent=true);
 
-    static QString queryTox1(const QString& record, bool silent=true); ///< Record should look like user@domain.tld. Do *NOT* use tox1 without a good reason, it's unsafe.
-    static QString queryTox3(const tox3_server& server, const QString& record, bool silent=true); ///< Record should look like user@domain.tld, will *NOT* fallback on queryTox1 anymore
+    static QString queryToxDNS1(const QString& record, bool silent=true); ///< Record should look like user@domain.tld. Do *NOT* use toxdns1 without a good reason, it's unsafe.
+    static QString queryToxDNS3(const toxdns3_server& server, const QString& record, bool silent=true); ///< Record should look like user@domain.tld, will *NOT* fallback on queryToxDNS1 anymore
 
 protected:
     static void showWarning(const QString& message);
@@ -61,7 +61,7 @@ private:
     static QByteArray fetchLastTextRecord(const QString& record, bool silent=true);
 
 public:
-    static const tox3_server pinnedServers[2];
+    static const toxdns3_server pinnedServers[2];
 };
 
 #endif // QTOXDNS_H


### PR DESCRIPTION
Depends on:
- toxcore PR: https://github.com/irungentoo/toxcore/pull/1309
- toxme.se PR: https://github.com/Tox/toxme.se/pull/26
- utox.org PR: https://github.com/notsecure/tox-dns/pull/1
- Tox-QuickDNS PR: https://github.com/Tox/Tox-QuickDNS/pull/2
- STS PR: https://github.com/Tox/Tox-STS/pull/48
